### PR TITLE
gcc is needed to compile graphite

### DIFF
--- a/vars/CentOS_7.yml
+++ b/vars/CentOS_7.yml
@@ -1,6 +1,7 @@
 ---
 
 graphite_requirements:
+  - gcc
   - python34-pip
   - python34-devel
   - python34-cairo


### PR DESCRIPTION
```
unable to execute 'gcc': No such file or directory
error: command 'gcc' failed with exit status 1
```
